### PR TITLE
Overhaul the entire library

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,29 +1,34 @@
 [alias]
-esp32   = "run --release --example hello_rgb --features=esp32   --target=xtensa-esp32-none-elf"
-esp32c2 = "run --release --example hello_rgb --features=esp32c2 --target=riscv32imc-unknown-none-elf"
-esp32c3 = "run --release --example hello_rgb --features=esp32c3 --target=riscv32imc-unknown-none-elf"
-esp32c6 = "run --release --example hello_rgb --features=esp32c6 --target=riscv32imac-unknown-none-elf"
-esp32h2 = "run --release --example hello_rgb --features=esp32h2 --target=riscv32imac-unknown-none-elf"
-esp32s2 = "run --release --example hello_rgb --features=esp32s2 --target=xtensa-esp32s2-none-elf"
-esp32s3 = "run --release --example hello_rgb --features=esp32s3 --target=xtensa-esp32s3-none-elf"
+esp32   = "run --release --features=esp32   --target=xtensa-esp32-none-elf"
+esp32c2 = "run --release --features=esp32c2 --target=riscv32imc-unknown-none-elf"
+esp32c3 = "run --release --features=esp32c3 --target=riscv32imc-unknown-none-elf"
+esp32c6 = "run --release --features=esp32c6 --target=riscv32imac-unknown-none-elf"
+esp32h2 = "run --release --features=esp32h2 --target=riscv32imac-unknown-none-elf"
+esp32s2 = "run --release --features=esp32s2 --target=xtensa-esp32s2-none-elf"
+esp32s3 = "run --release --features=esp32s3 --target=xtensa-esp32s3-none-elf"
 
 [target.'cfg(target_arch = "riscv32")']
-runner    = "espflash flash --monitor"
+runner    = "espflash flash --monitor --log-format defmt"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "force-frame-pointers",
+  # defmt
+  "-C", "link-arg=-Tdefmt.x",
 ]
 
 [target.'cfg(target_arch = "xtensa")']
-runner    = "espflash flash --monitor"
+runner    = "espflash flash --monitor --log-format defmt"
 rustflags = [
   # GNU LD
   "-C", "link-arg=-Wl,-Tlinkall.x",
   "-C", "link-arg=-nostartfiles",
+  # defmt
+  "-C", "link-arg=-Wl,-Tdefmt.x",
 
   # LLD
   # "-C", "link-arg=-Tlinkall.x",
   # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tdefmt.x",
 ]
 
 [unstable]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,11 @@
 [alias]
-esp32   = "run --release --features=esp32   --target=xtensa-esp32-none-elf"
-esp32c2 = "run --release --features=esp32c2 --target=riscv32imc-unknown-none-elf"
-esp32c3 = "run --release --features=esp32c3 --target=riscv32imc-unknown-none-elf"
-esp32c6 = "run --release --features=esp32c6 --target=riscv32imac-unknown-none-elf"
-esp32h2 = "run --release --features=esp32h2 --target=riscv32imac-unknown-none-elf"
-esp32s2 = "run --release --features=esp32s2 --target=xtensa-esp32s2-none-elf"
-esp32s3 = "run --release --features=esp32s3 --target=xtensa-esp32s3-none-elf"
+esp32   = "run --release --example hello_rgb --features=esp32   --target=xtensa-esp32-none-elf"
+esp32c2 = "run --release --example hello_rgb --features=esp32c2 --target=riscv32imc-unknown-none-elf"
+esp32c3 = "run --release --example hello_rgb --features=esp32c3 --target=riscv32imc-unknown-none-elf"
+esp32c6 = "run --release --example hello_rgb --features=esp32c6 --target=riscv32imac-unknown-none-elf"
+esp32h2 = "run --release --example hello_rgb --features=esp32h2 --target=riscv32imac-unknown-none-elf"
+esp32s2 = "run --release --example hello_rgb --features=esp32s2 --target=xtensa-esp32s2-none-elf"
+esp32s3 = "run --release --example hello_rgb --features=esp32s3 --target=xtensa-esp32s3-none-elf"
 
 [target.'cfg(target_arch = "riscv32")']
 runner    = "espflash flash --monitor"
@@ -25,15 +25,6 @@ rustflags = [
   # "-C", "link-arg=-Tlinkall.x",
   # "-C", "linker=rust-lld",
 ]
-
-[env]
-ESP_LOG = "info"
-SSID = "SSID"
-PASSWORD = "PASSWORD"
-STATIC_IP = "1.1.1.1 "
-GATEWAY_IP = "1.1.1.1"
-HOST_IP = "1.1.1.1"
-ESP_WIFI_CSI_ENABLE = "true"
 
 [unstable]
 build-std = ["alloc", "core"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-smartled2"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-smartled2"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-executor"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+dependencies = [
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros",
+ "embassy-executor-timer-queue",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
+
+[[package]]
 name = "embassy-futures"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +323,41 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "futures-core",
  "futures-sink",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-utils"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+dependencies = [
+ "embassy-executor-timer-queue",
  "heapless 0.8.0",
 ]
 
@@ -558,10 +623,13 @@ version = "0.23.0"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
+ "embassy-executor",
+ "embassy-time",
  "esp-backtrace",
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-println",
+ "esp-rtos",
  "smart-leds",
  "smart-leds-trait",
 ]
@@ -578,6 +646,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
 dependencies = [
+ "defmt 1.0.1",
  "document-features",
  "esp-metadata-generated",
  "esp-sync",
@@ -606,6 +675,27 @@ dependencies = [
  "cfg-if",
  "document-features",
  "esp-metadata-generated",
+]
+
+[[package]]
+name = "esp-rtos"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
+dependencies = [
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-executor",
+ "embassy-sync 0.7.2",
+ "embassy-time-driver",
+ "embassy-time-queue-utils",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-sync",
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-smartled2"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-hal-smartled"
+name = "esp-hal-smartled2"
 version = "0.23.0"
 dependencies = [
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-smartled2"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-smartled2"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,40 +3,25 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
-
-[[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitfield"
-version = "0.18.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e6caee68becd795bfd65f1a026e4d00d8f0c2bc9be5eb568e1015f9ce3c34"
+checksum = "6bf79f42d21f18b5926a959280215903e659760da994835d27c3a0c5ff4f898f"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.18.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331afbb18ce7b644c0b428726d369c5dd37ca0b815d72a459fcc2896c3c8ad32"
+checksum = "6115af052c7914c0cbb97195e5c72cb61c511527250074f5c041d1048b0d8b16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -51,15 +36,24 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -69,17 +63,17 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.40"
+name = "cpufeatures"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
- "num-traits",
+ "libc",
 ]
 
 [[package]]
@@ -89,20 +83,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "darling"
-version = "0.20.10"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -113,21 +127,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.20.10"
+name = "darling_core"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
- "darling_core",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "defmt"
-version = "0.3.10"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f6162c53f659f65d00619fe31f14556a6e9f8752ccc4a41bd177ffcf3d6130"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -135,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d135dd939bad62d7490b0002602d35b358dce5fd9233a709d3c1ef467d4bde6"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -148,18 +195,18 @@ dependencies = [
 
 [[package]]
 name = "defmt-parser"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3983b127f13995e68c1e29071e5d115cd96f215ccb5e6812e3728cd6f92653b3"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "delegate"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
+checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -167,23 +214,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.11"
+name = "digest"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fea5ef5bed4d3468dfd44f5c9fa4cda8f54c86d4fb4ae683eacf9d39e2ea12"
+checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
 dependencies = [
  "embassy-futures",
- "embassy-sync",
- "embassy-time",
+ "embassy-hal-internal",
+ "embassy-sync 0.7.2",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -193,35 +250,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-executor"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90327bcc66333a507f89ecc4e2d911b265c45f5c9bc241f98eee076752d35ac6"
-dependencies = [
- "critical-section",
- "document-features",
- "embassy-executor-macros",
-]
-
-[[package]]
-name = "embassy-executor-macros"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "embassy-futures"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 dependencies = [
- "defmt",
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "embassy-hal-internal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95285007a91b619dc9f26ea8f55452aa6c60f7115a4edc05085cd2bd3127cd7a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -232,62 +275,44 @@ checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt",
- "embedded-io-async",
+ "embedded-io-async 0.6.1",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
-name = "embassy-time"
-version = "0.4.0"
+name = "embassy-sync"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
 dependencies = [
  "cfg-if",
  "critical-section",
- "document-features",
- "embassy-time-driver",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "futures-util",
-]
-
-[[package]]
-name = "embassy-time-driver"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d45f5d833b6d98bd2aab0c2de70b18bfaa10faf661a1578fd8e5dfb15eb7eba"
-dependencies = [
- "document-features",
-]
-
-[[package]]
-name = "embassy-time-queue-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc55c748d16908a65b166d09ce976575fb8852cf60ccd06174092b41064d8f83"
-dependencies = [
- "embassy-executor",
- "heapless",
+ "defmt 1.0.1",
+ "embedded-io-async 0.6.1",
+ "futures-core",
+ "futures-sink",
+ "heapless 0.8.0",
 ]
 
 [[package]]
 name = "embassy-usb-driver"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc247028eae04174b6635104a35b1ed336aabef4654f5e87a8f32327d231970"
+checksum = "17119855ccc2d1f7470a39756b12068454ae27a3eabb037d940b5c03d9c77b7a"
+dependencies = [
+ "embedded-io-async 0.6.1",
+]
 
 [[package]]
 name = "embassy-usb-synopsys-otg"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e753b23799329780c7ac434264026d0422044d6649ed70a73441b14a6436d7"
+checksum = "288751f8eaa44a5cf2613f13cee0ca8e06e6638cb96e897e6834702c79084b23"
 dependencies = [
  "critical-section",
- "embassy-sync",
+ "embassy-sync 0.7.2",
  "embassy-usb-driver",
 ]
 
@@ -315,9 +340,6 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
-dependencies = [
- "defmt",
-]
 
 [[package]]
 name = "embedded-hal-async"
@@ -334,7 +356,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 dependencies = [
- "defmt",
+ "defmt 0.3.100",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+dependencies = [
+ "defmt 1.0.1",
 ]
 
 [[package]]
@@ -343,8 +374,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "defmt",
- "embedded-io",
+ "defmt 0.3.100",
+ "embedded-io 0.6.1",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -363,33 +404,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "enumset"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
 dependencies = [
+ "defmt 1.0.1",
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -403,67 +433,86 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-backtrace"
-version = "0.15.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cd70abe47945c9116972781b5c05277ad855a5f5569fe2afd3e2e61a103cc0"
+checksum = "3318413fb566c7227387f67736cf70cd74d80a11f2bb31c7b95a9eb48d079669"
 dependencies = [
- "esp-build",
+ "cfg-if",
+ "document-features",
+ "esp-config",
+ "esp-metadata-generated",
  "esp-println",
+ "heapless 0.9.1",
+ "riscv",
  "semihosting",
+ "xtensa-lx",
 ]
 
 [[package]]
-name = "esp-build"
-version = "0.2.0"
+name = "esp-bootloader-esp-idf"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa1c8f9954c9506699cf1ca10a2adcc226ff10b6ae3cb9e875cf2c6a0b9a372"
+checksum = "02a56964ab5479ac20c9cf76fa3b0d3f2233b20b5d8554e81ef5d65f63c20567"
 dependencies = [
- "quote",
- "syn",
- "termcolor",
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embedded-storage",
+ "esp-config",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-rom-sys",
+ "jiff",
+ "strum",
 ]
 
 [[package]]
 name = "esp-config"
-version = "0.3.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158dba334d3a2acd8d93873c0ae723ca1037cc78eefe5d6b4c5919b0ca28e38e"
+checksum = "102871054f8dd98202177b9890cb4b71d0c6fe1f1413b7a379a8e0841fc2473c"
 dependencies = [
  "document-features",
+ "esp-metadata-generated",
+ "serde",
+ "serde_yaml",
+ "somni-expr",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0-beta.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9efaa9c1324ca20a22086aba2ce47a9bdc5bd65969af8b0cd5e879603b57bef"
+checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
 dependencies = [
- "basic-toml",
  "bitfield",
- "bitflags 2.9.0",
+ "bitflags 2.10.0",
  "bytemuck",
  "cfg-if",
- "chrono",
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "delegate",
+ "digest",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync",
+ "embassy-sync 0.7.2",
  "embassy-usb-driver",
  "embassy-usb-synopsys-otg",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io",
- "embedded-io-async",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "enumset",
- "esp-build",
  "esp-config",
  "esp-hal-procmacros",
- "esp-metadata",
+ "esp-metadata-generated",
  "esp-riscv-rt",
+ "esp-rom-sys",
+ "esp-sync",
  "esp-synopsys-usb-otg",
  "esp32",
  "esp32c2",
@@ -477,105 +526,102 @@ dependencies = [
  "nb 1.1.0",
  "paste",
  "portable-atomic",
- "rand_core",
+ "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "riscv",
- "serde",
- "strum 0.27.1",
+ "sha1",
+ "sha2",
+ "strum",
  "ufmt-write",
- "usb-device",
- "void",
  "xtensa-lx",
  "xtensa-lx-rt",
 ]
 
 [[package]]
-name = "esp-hal-embassy"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27f41110117a9bf2be385b42535c686b301c8ce3b5ea0a07567e200a63a2239"
-dependencies = [
- "critical-section",
- "document-features",
- "embassy-executor",
- "embassy-sync",
- "embassy-time",
- "embassy-time-driver",
- "embassy-time-queue-utils",
- "esp-build",
- "esp-config",
- "esp-hal",
- "esp-hal-procmacros",
- "esp-metadata",
- "portable-atomic",
- "static_cell",
-]
-
-[[package]]
 name = "esp-hal-procmacros"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd340a20a7d546570af58fd9e2aae17466a42572680d8e70d35fc7c475c4ed8"
+checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
 dependencies = [
- "darling",
  "document-features",
- "litrs",
  "object",
  "proc-macro-crate",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
+ "termcolor",
 ]
 
 [[package]]
 name = "esp-hal-smartled"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "cfg-if",
- "defmt",
- "document-features",
+ "defmt 1.0.1",
  "esp-backtrace",
+ "esp-bootloader-esp-idf",
  "esp-hal",
- "esp-hal-embassy",
  "esp-println",
- "fugit",
  "smart-leds",
  "smart-leds-trait",
 ]
 
 [[package]]
-name = "esp-metadata"
-version = "0.6.0"
+name = "esp-metadata-generated"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b4bffc22b7b1222c9467f0cb90eb49dcb63de810ecb3300e4b3bbc4ac2423e"
-dependencies = [
- "anyhow",
- "basic-toml",
- "serde",
- "strum 0.26.3",
-]
+checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
 
 [[package]]
 name = "esp-println"
-version = "0.13.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960703930f9f3c899ddedd122ea27a09d6a612c22323157e524af5b18876448e"
+checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
 dependencies = [
- "critical-section",
- "esp-build",
+ "document-features",
+ "esp-metadata-generated",
+ "esp-sync",
  "log",
  "portable-atomic",
 ]
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec69987b3d7c48b65f8fb829220832a101478d766c518ae836720d040608d5dd"
+checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
 dependencies = [
+ "defmt 1.0.1",
  "document-features",
  "riscv",
- "riscv-rt-macros",
+ "riscv-rt",
+]
+
+[[package]]
+name = "esp-rom-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd66cccc6dd2d13e9f33668a57717ab14a6d217180ec112e6be533de93e7ecbf"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "esp-metadata-generated",
+]
+
+[[package]]
+name = "esp-sync"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44974639b4e88914f83fe60d2832c00276657d7d857628fdfc966cc7302e8a8"
+dependencies = [
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-sync 0.6.2",
+ "embassy-sync 0.7.2",
+ "esp-metadata-generated",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
@@ -593,78 +639,78 @@ dependencies = [
 
 [[package]]
 name = "esp32"
-version = "0.36.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9b774d7a2c96550a5c25016c2abd33370ebac60e534484b7bca344ecb8a3d6"
+checksum = "b76170a463d18f888a1ad258031901036fd827a9ef126733053ba5f8739fb0c8"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c2"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7037cfa7c93574b0891062f980a75ae97e9d6c93dcaff3e060b37cf1281c59"
+checksum = "e62cf8932966b8d445b6f1832977b468178f0a84effb2e9fda89f60c24d45aa3"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c3"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1bbcfa3ab2979171263db80804dabc38bdd45450c7eb775ee3f81d552cf0ba"
+checksum = "356af3771d0d6536c735bf71136594f4d1cbb506abf6e0c51a6639e9bf4e7988"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c6"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff2a4e1d1b0cb2517af20766004b8e8fb4612043f0b0569703cc90d1880ede4"
+checksum = "8f5e511df672d79cd63365c92045135e01ba952b6bddd25b660baff5e1110f6b"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32h2"
-version = "0.15.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee7512ae8da61338545804a76c5bc9816a9122abbf2f23d1195e3d45fab79af"
+checksum = "ed4a50bbd1380931e095e0973b9b12f782a9c481f2edf1f7c42e7eb4ff736d6d"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s2"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22733ee6f4bb08e3113df6651b2c350f37c44314017476e354ec951a55465e9"
+checksum = "98574d4c577fbe888fe3e6df7fc80d25a05624d9998f7d7de1500ae21fcca78f"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s3"
-version = "0.31.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6d20f119410092abfbc65e46f9362015a7110023528f0dbe855cab80c38ca8"
+checksum = "1810d8ee4845ef87542af981e38eb80ab531d0ef1061e1486014ab7af74c337a"
 dependencies = [
  "critical-section",
- "defmt",
+ "defmt 1.0.1",
  "vcell",
 ]
 
@@ -680,7 +726,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
- "defmt",
+ "defmt 0.3.100",
  "gcd",
 ]
 
@@ -721,6 +767,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,15 +787,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32",
  "stable_deref_trait",
@@ -759,9 +825,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -769,17 +835,20 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -787,34 +856,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "litrs"
-version = "0.4.1"
+name = "itoa"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "minijinja"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e36f1329330bb1614c94b78632b9ce45dd7d761f3304a1bed07b2990a7c5097"
-dependencies = [
- "serde",
-]
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nb"
@@ -842,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -869,18 +962,24 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
- "critical-section",
+ "portable-atomic",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -909,27 +1008,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r0"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
 name = "ral-registers"
@@ -944,19 +1037,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "rgb"
-version = "0.8.50"
+name = "rand_core"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-dependencies = [
- "bytemuck",
-]
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "riscv"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea8ff73d3720bdd0a97925f0bf79ad2744b6da8ff36be3840c48ac81191d7a7"
+checksum = "b05cfa3f7b30c84536a9025150d44d26b8e1cc20ddf436448d74cd9591eefb25"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",
@@ -967,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "riscv-macros"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
+checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -983,10 +1079,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
-name = "riscv-rt-macros"
-version = "0.4.0"
+name = "riscv-rt"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71814687c45ba4cd1e47a54e03a2dbc62ca3667098fbae9cc6b423956758fa"
+checksum = "3d07b9f3a0eff773fc4df11f44ada4fa302e529bff4b7fe7e6a4b98a65ce9174"
+dependencies = [
+ "defmt 1.0.1",
+ "riscv",
+ "riscv-pac",
+ "riscv-rt-macros",
+ "riscv-target-parser",
+]
+
+[[package]]
+name = "riscv-rt-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c3138fdd8d128b2d81829842a3e0ce771b3712f7b6318ed1476b0695e7d330"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -994,31 +1103,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "riscv-target-parser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
+
+[[package]]
 name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semihosting"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407ec8d274cd77556e9c2bef886df91eb3447b4059e603d6fb19f85e6452e275"
+checksum = "c3e1c7d2b77d80283c750a39c52f1ab4d17234e8f30bca43550f5b2375f41d5f"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1026,12 +1157,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
  "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1045,27 +1202,33 @@ dependencies = [
 
 [[package]]
 name = "smart-leds-trait"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edeb89c73244414bb0568611690dd095b2358b3fda5bae65ad784806cca00157"
+checksum = "a7f4441a131924d58da6b83a7ad765c460e64630cce504376c3a87a2558c487f"
 dependencies = [
  "rgb",
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
+name = "somni-expr"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "3ed9b7648d5e8b2df6c5e49940c54bcdd2b4dd71eafc6e8f1c714eb4581b0f53"
+dependencies = [
+ "somni-parser",
+]
 
 [[package]]
-name = "static_cell"
-version = "2.1.0"
+name = "somni-parser"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89b0684884a883431282db1e4343f34afc2ff6996fe1f4a1664519b66e14c1e"
-dependencies = [
- "portable-atomic",
-]
+checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1075,53 +1238,30 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
-dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1139,18 +1279,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1158,38 +1298,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
+ "toml_parser",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ufmt-write"
@@ -1199,9 +1341,15 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "usb-device"
@@ -1209,7 +1357,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
@@ -1220,6 +1368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,130 +1381,64 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xtensa-lx"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51cbb46c78cfd284c9378070ab90bae9d14d38b3766cb853a97c0a137f736d5b"
+checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
 dependencies = [
  "critical-section",
- "document-features",
 ]
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689c2ef159d9cd4fc9503603e9999968a84a30db9bde0f0f880d0cceea0190a9"
+checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
 dependencies = [
- "anyhow",
+ "defmt 1.0.1",
  "document-features",
- "enum-as-inner",
- "minijinja",
- "r0",
- "serde",
- "strum 0.26.3",
- "toml",
  "xtensa-lx",
  "xtensa-lx-rt-proc-macros",
 ]
 
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.2.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11277b1e4cbb7ffe44678c668518b249c843c81df249b8f096701757bc50d7ee"
+checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
- "darling",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "esp-hal-smartled"
 version = "0.23.0"
 edition = "2024"
 rust-version = "1.91"
+license = "MIT OR Apache-2.0"
+description = "smart-leds driver for esp-hal using RMT peripheral"
 
 [dependencies]
 esp-hal = { version = "=1.0.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "esp-hal-smartled2"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.90"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kleinesfilmroellchen/esp-hal-smartled"
 documentation = "https://docs.rs/esp-hal-smartled2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ esp32s3 = [
 [package.metadata.docs.rs]
 # use a RISC-V chip and target for docs.rs as it doesn’t require a special compiler
 features = ["esp32c3", "esp-hal/unstable"]
-default-target = "riscv32imac-unknown-none-elf"
-targets = ["riscv32imac-unknown-none-elf"]
+default-target = "riscv32imc-unknown-none-elf"
+targets = ["riscv32imc-unknown-none-elf"]
 
 [dev-dependencies]
 # example runs on ESP32-C6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-name = "esp-hal-smartled"
+name = "esp-hal-smartled2"
 version = "0.23.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 description = "smart-leds driver for esp-hal using RMT peripheral"
+
+[lib]
+name = "esp_hal_smartled"
 
 [dependencies]
 esp-hal = { version = "=1.0.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,68 +1,76 @@
 [package]
 name = "esp-hal-smartled"
-version = "0.22.0"
-edition = "2021"
+version = "0.23.0"
+edition = "2024"
+rust-version = "1.91"
 
 [dependencies]
-esp-hal = { version = "1.0.0-beta.0", features = ["unstable"], optional = true }
-esp-hal-embassy = { version = "0.7", optional = true }
-smart-leds-trait = "0.3"
-fugit = "0.3"
-document-features = "0.2.10"
-defmt = { version = "0.3.8", optional = true }
-
-[dev-dependencies]
-esp-hal = { version = "1.0.0-beta.0" }
-esp-backtrace = { version = "0.15", features = [
-    "exception-handler",
-    "panic-handler",
-    "println",
+esp-hal = { version = "=1.0.0", default-features = false, features = [
+    "requires-unstable",
 ] }
-esp-println = { version = "0.13", features = ["auto"] }
-smart-leds = "0.4"
-cfg-if = "1"
+smart-leds-trait = "0.3"
+defmt = { version = "1", optional = true }
 
 [features]
-defmt = ["dep:defmt", "esp-hal/defmt"]
+defmt = ["dep:defmt", "esp-hal/defmt", "esp-bootloader-esp-idf/defmt"]
+
+# unfortunately necessary ...
+# not to be used by upstream.
+
 esp32 = [
     "esp-hal/esp32",
-    "esp-hal-embassy?/esp32",
-    "esp-backtrace/esp32",
     "esp-println/esp32",
+    "esp-backtrace/esp32",
+    "esp-bootloader-esp-idf/esp32",
 ]
 esp32c2 = [
     "esp-hal/esp32c2",
-    "esp-hal-embassy?/esp32c2",
-    "esp-backtrace/esp32c2",
     "esp-println/esp32c2",
+    "esp-backtrace/esp32c2",
+    "esp-bootloader-esp-idf/esp32c2",
 ]
 esp32c3 = [
     "esp-hal/esp32c3",
-    "esp-hal-embassy?/esp32c3",
-    "esp-backtrace/esp32c3",
     "esp-println/esp32c3",
+    "esp-backtrace/esp32c3",
+    "esp-bootloader-esp-idf/esp32c3",
 ]
 esp32c6 = [
     "esp-hal/esp32c6",
-    "esp-hal-embassy?/esp32c6",
-    "esp-backtrace/esp32c6",
     "esp-println/esp32c6",
+    "esp-backtrace/esp32c6",
+    "esp-bootloader-esp-idf/esp32c6",
 ]
 esp32h2 = [
     "esp-hal/esp32h2",
-    "esp-hal-embassy?/esp32h2",
-    "esp-backtrace/esp32h2",
     "esp-println/esp32h2",
+    "esp-backtrace/esp32h2",
+    "esp-bootloader-esp-idf/esp32h2",
 ]
 esp32s2 = [
     "esp-hal/esp32s2",
-    "esp-hal-embassy?/esp32s2",
-    "esp-backtrace/esp32s2",
     "esp-println/esp32s2",
+    "esp-backtrace/esp32s2",
+    "esp-bootloader-esp-idf/esp32s2",
 ]
 esp32s3 = [
     "esp-hal/esp32s3",
-    "esp-hal-embassy?/esp32s3",
-    "esp-backtrace/esp32s3",
     "esp-println/esp32s3",
+    "esp-backtrace/esp32s3",
+    "esp-bootloader-esp-idf/esp32s3",
 ]
+
+[package.metadata.docs.rs]
+# use a RISC-V chip and target for docs.rs as it doesn’t require a special compiler
+features = ["esp32c3", "esp-hal/unstable"]
+default-target = "riscv32imac-unknown-none-elf"
+targets = ["riscv32imac-unknown-none-elf"]
+
+[dev-dependencies]
+# example runs on ESP32-C6
+esp-hal = { version = "=1.0.0", features = ["unstable"] }
+esp-backtrace = { version = "0.18", features = ["panic-handler", "println"] }
+esp-println = { version = "0.16", features = ["auto"] }
+esp-bootloader-esp-idf = { version = "0.4.0" }
+smart-leds = "0.4"
+cfg-if = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-hal-smartled2"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-hal-smartled2"
-version = "0.25.1"
+version = "0.26.0"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-hal-smartled2"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.23.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/kleinesfilmroellchen/esp-hal-smartled"
+documentation = "https://docs.rs/esp-hal-smartled2"
 description = "smart-leds driver for esp-hal using RMT peripheral"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-hal-smartled2"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ smart-leds-trait = "0.3"
 defmt = { version = "1", optional = true }
 
 [features]
-defmt = ["dep:defmt", "esp-hal/defmt", "esp-bootloader-esp-idf/defmt"]
+defmt = [
+    "dep:defmt",
+    "esp-hal/defmt",
+    "esp-bootloader-esp-idf/defmt",
+    "esp-rtos/defmt",
+]
 
 # unfortunately necessary ...
 # not to be used by upstream.
@@ -24,42 +29,49 @@ esp32 = [
     "esp-println/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
+    "esp-rtos/esp32",
 ]
 esp32c2 = [
     "esp-hal/esp32c2",
     "esp-println/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
+    "esp-rtos/esp32c2",
 ]
 esp32c3 = [
     "esp-hal/esp32c3",
     "esp-println/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
+    "esp-rtos/esp32c3",
 ]
 esp32c6 = [
     "esp-hal/esp32c6",
     "esp-println/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
+    "esp-rtos/esp32c6",
 ]
 esp32h2 = [
     "esp-hal/esp32h2",
     "esp-println/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
+    "esp-rtos/esp32h2",
 ]
 esp32s2 = [
     "esp-hal/esp32s2",
     "esp-println/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
+    "esp-rtos/esp32s2",
 ]
 esp32s3 = [
     "esp-hal/esp32s3",
     "esp-println/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
+    "esp-rtos/esp32s3",
 ]
 
 [package.metadata.docs.rs]
@@ -69,10 +81,12 @@ default-target = "riscv32imc-unknown-none-elf"
 targets = ["riscv32imc-unknown-none-elf"]
 
 [dev-dependencies]
-# example runs on ESP32-C6
 esp-hal = { version = "=1.0.0", features = ["unstable"] }
+esp-rtos = { version = "0.2", features = ["embassy"] }
 esp-backtrace = { version = "0.18", features = ["panic-handler", "println"] }
-esp-println = { version = "0.16", features = ["auto"] }
+esp-println = { version = "0.16", features = ["defmt-espflash", "auto"] }
 esp-bootloader-esp-idf = { version = "0.4.0" }
 smart-leds = "0.4"
 cfg-if = "1"
+embassy-executor = "0.9"
+embassy-time = "0.5"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # esp-hal-smartled
 
-[![Crates.io](https://img.shields.io/crates/v/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-smartled)
-[![docs.rs](https://img.shields.io/docsrs/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal-smartled)
-![MSRV](https://img.shields.io/badge/MSRV-1.91-blue?labelColor=1C2C2E&style=flat-square)
-![Crates.io](https://img.shields.io/crates/l/esp-hal-smartled?labelColor=1C2C2E&style=flat-square)
+[![Crates.io](https://img.shields.io/crates/v/esp-hal-smartled2?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-smartled2)
+[![docs.rs](https://img.shields.io/docsrs/esp-hal-smartled2?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal-smartled2)
+![MSRV](https://img.shields.io/badge/MSRV-1.90-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-hal-smartled2?labelColor=1C2C2E&style=flat-square)
 
 > **NOTE:** This is an enhanced up-to-date fork of [esp-hal-smartled](https://crates.io/crates/esp-hal-smartled), which seems abandoned at the time of writing. Users of `esp-hal-smartled` can migrate to `esp-hal-smartled2` with minimal effort. If possible, this crate’s features will be merged into `esp-hal-smartled`.
 
@@ -13,7 +13,7 @@ Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-r
 
 ## [Documentation]
 
-[documentation]: https://docs.rs/esp-hal-smartled/
+[documentation]: https://docs.rs/esp-hal-smartled2/
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,27 @@ Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-r
 
 [documentation]: https://docs.rs/esp-hal-smartled2/
 
+Also have a look at the [examples](https://github.com/kleinesfilmroellchen/esp-hal-smartled/blob/main/examples).
+
 ## Compatibility
 
 This crate is guaranteed to compile on whatever Rust version esp-hal requires, which is the latest stable version at the time of release. It _might_ compile with older versions but that may change in any new patch release.
 
 This crate uses the unstable RMT peripheral from esp-hal. Therefore, it is compatible with _exactly_ esp-hal 1.0.0, as the peripheral API might change in any future release and is likely to go through significant changes before stabilization. In order to use this crate, you have to enable the `unstable` feature on esp-hal.
+
+### Migration
+
+- `0.26`
+  - `SmartLedsAdapter::new` now returns `Result<SmartLedsAdapter, RmtError>`, so that you can handle configuration errors if desired.
+  - `SmartLedsAdapter::new_with_memsize` was added to specify a larger RMT memory size when desired.
+- `0.25`
+  - WS2811 timings have been changed to use fast timings instead of slow timings; slow timings are still available through `Ws2811LowSpeedTiming`. If you experience issues with WS2811, switch to the low-speed timing.
+- `0.24`
+  - `SmartLedsWriteAsync` is now implemented for async RMT channels. Refer to the [async example](https://github.com/kleinesfilmroellchen/esp-hal-smartled/blob/main/examples/hello_rgb_async.rs) for more information.
+- `0.23` (from `esp-hal-smartled`):
+  - `SmartLedAdapter` now takes type parameters describing the timing and LED buffer size.
+  - It is no longer needed to allocate a separate buffer and pass it into `new`. The `smartLedBuffer!` macro has been removed, and the `buffer_size` function can be used instead to calculate the correct buffer size.
+  - Have a look at the documentation or the [example](https://github.com/kleinesfilmroellchen/esp-hal-smartled/blob/main/examples/hello_rgb.rs) for details.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-smartled)
 [![docs.rs](https://img.shields.io/docsrs/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal-smartled)
-![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.91-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal-smartled?labelColor=1C2C2E&style=flat-square)
-[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-Allows for the use of an RMT output channel to easily interact with RGB LEDs and use the convenience functions of the [smart-leds] crate.
+Allows for the use of an RMT output channel on the ESP32 family to easily drive smart RGB LEDs. This is a driver for the [smart-leds](https://crates.io/crates/smart-leds) framework and allows using the utility functions from this crate as well as higher-level libraries based on smart-leds.
 
-[smart-leds]: https://crates.io/crates/smart-leds
+Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-rmt-driver), which is based on the unofficial `esp-idf` SDK, this crate is based on the official no-std [esp-hal](https://github.com/esp-rs/esp-hal).
 
 ## [Documentation]
 
 [documentation]: https://docs.rs/esp-hal-smartled/
 
-## Minimum Supported Rust Version (MSRV)
+## Compatibility
 
-This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on whatever Rust version esp-hal requires, which is the latest stable version at the time of release. It _might_ compile with older versions but that may change in any new patch release.
+
+This crate uses the unstable RMT peripheral from esp-hal. Therefore, it is compatible with *exactly* esp-hal 1.0.0, as the peripheral API might change in any future release and is likely to go through significant changes before stabilization. In order to use this crate, you have to enable the `unstable` feature on esp-hal.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
 
 Allows for the use of an RMT output channel on the ESP32 family to easily drive smart RGB LEDs. This is a driver for the [smart-leds](https://crates.io/crates/smart-leds) framework and allows using the utility functions from this crate as well as higher-level libraries based on smart-leds.
 
-Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-rmt-driver), which is based on the unofficial `esp-idf` SDK, this crate is based on the official no-std [esp-hal](https://github.com/esp-rs/esp-hal).
+Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-rmt-driver), which is based on the unofficial `esp-idf` SDK, this crate is based on the official no-std [esp-hal](https://github.com/esp-rs/esp-hal). The RMT peripheral approach is common across many smart LED drivers on ESP32, like Arduino FastLED.
+
+## Features
+
+- **Configurability**: Use any color order and timing specification you want, either from the library itself, or your own. This makes `esp-hal-smartled2` compatible with many types of LEDs. Since both of these are determined at compile-time, the driver is always well-optimized for your specific LED type. (Currently, only RGB LEDs are supported, and RGBW/RGBWW/CC support might be added in the future.)
+- **Async support**: The async write trait of smart-leds is supported, allowing you to use the driver without waiting for the LED write to complete.
+- **No Allocation**: The driver uses only static buffers based on the maximum number of LEDs to drive, so you can use it without an allocator.
 
 ## [Documentation]
 
@@ -19,7 +25,7 @@ Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-r
 
 This crate is guaranteed to compile on whatever Rust version esp-hal requires, which is the latest stable version at the time of release. It _might_ compile with older versions but that may change in any new patch release.
 
-This crate uses the unstable RMT peripheral from esp-hal. Therefore, it is compatible with *exactly* esp-hal 1.0.0, as the peripheral API might change in any future release and is likely to go through significant changes before stabilization. In order to use this crate, you have to enable the `unstable` feature on esp-hal.
+This crate uses the unstable RMT peripheral from esp-hal. Therefore, it is compatible with _exactly_ esp-hal 1.0.0, as the peripheral API might change in any future release and is likely to go through significant changes before stabilization. In order to use this crate, you have to enable the `unstable` feature on esp-hal.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ![MSRV](https://img.shields.io/badge/MSRV-1.91-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal-smartled?labelColor=1C2C2E&style=flat-square)
 
+> **NOTE:** This is an enhanced up-to-date fork of [esp-hal-smartled](https://crates.io/crates/esp-hal-smartled), which seems abandoned at the time of writing. Users of `esp-hal-smartled` can migrate to `esp-hal-smartled2` with minimal effort. If possible, this crate’s features will be merged into `esp-hal-smartled`.
+
 Allows for the use of an RMT output channel on the ESP32 family to easily drive smart RGB LEDs. This is a driver for the [smart-leds](https://crates.io/crates/smart-leds) framework and allows using the utility functions from this crate as well as higher-level libraries based on smart-leds.
 
 Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-rmt-driver), which is based on the unofficial `esp-idf` SDK, this crate is based on the official no-std [esp-hal](https://github.com/esp-rs/esp-hal).

--- a/examples/hello_rgb.rs
+++ b/examples/hello_rgb.rs
@@ -69,10 +69,11 @@ fn main() -> ! {
     let mut led = {
         let rmt = Rmt::new(peripherals.RMT, freq).expect("Failed to initialize RMT0");
         // Configure color order and timing implementation as needed.
-        SmartLedsAdapter::<{ buffer_size(1) }, Blocking, color_order::Rgb, Ws2812Timing>::new(
+        SmartLedsAdapter::<{ buffer_size(1) }, Blocking, color_order::Rgb, Ws2812Timing>::new_with_memsize(
             rmt.channel0,
             led_pin,
-        )
+            2,
+        ).unwrap()
     };
     let delay = Delay::new();
 

--- a/examples/hello_rgb_async.rs
+++ b/examples/hello_rgb_async.rs
@@ -1,0 +1,105 @@
+//! RGB LED Demo - Async version.
+//!
+//! This example drives an SK68XX RGB LED, which is connected to a pin on the
+//! official DevKits.
+//!
+//! It is the exact same as the `hello_rgb` example,
+//! except it uses the async driver on top of embassy.
+//! 
+//! Requires the `defmt` feature.
+
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use esp_backtrace as _;
+use esp_hal::interrupt::software::SoftwareInterruptControl;
+use esp_hal::timer::timg::TimerGroup;
+use esp_hal::{Async, Blocking, delay::Delay, rmt::Rmt, time::Rate};
+use esp_hal_smartled::{SmartLedsAdapter, Ws2812Timing, buffer_size, color_order};
+use smart_leds::{
+    SmartLedsWriteAsync, brightness, gamma,
+    hsv::{Hsv, hsv2rgb},
+};
+use embassy_time::Timer;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    let software_interrupt = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
+
+    // Each devkit uses a unique GPIO for the RGB LED, so in order to support
+    // all chips we must unfortunately use `#[cfg]`s:
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let led_pin = peripherals.GPIO33;
+        } else if #[cfg(feature = "esp32c3")] {
+            let led_pin = peripherals.GPIO8;
+        } else if #[cfg(any(feature = "esp32c6", feature = "esp32h2"))] {
+            let led_pin = peripherals.GPIO8;
+        } else if #[cfg(feature = "esp32s2")] {
+            let led_pin = peripherals.GPIO18;
+        } else if #[cfg(feature = "esp32s3")] {
+            let led_pin = peripherals.GPIO48;
+        }
+    }
+
+    // Configure RMT peripheral globally
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32h2")] {
+            let freq = Rate::from_mhz(32);
+        } else {
+            let freq = Rate::from_mhz(80);
+        }
+    }
+
+    let mut led = {
+        let rmt = Rmt::new(peripherals.RMT, freq).expect("Failed to initialize RMT0").into_async();
+        // Configure color order and timing implementation as needed.
+        SmartLedsAdapter::<{ buffer_size(1) }, Async, color_order::Rgb, Ws2812Timing>::new(
+            rmt.channel0,
+            led_pin,
+        )
+    };
+
+    let mut color = Hsv {
+        hue: 0,
+        sat: 255,
+        val: 255,
+    };
+    let mut data;
+
+    spawner.must_spawn(background_print());
+
+    loop {
+        // Iterate over the rainbow!
+        for hue in 0..=255 {
+            color.hue = hue;
+            // Convert from the HSV color space (where we can easily transition from one
+            // color to the other) to the RGB color space that we can then send to the LED
+            data = [hsv2rgb(color)];
+            // When sending to the LED, we do a gamma correction first (see smart_leds
+            // documentation for details) and then limit the brightness to 10 out of 255 so
+            // that the output it's not too bright.
+            led.write(brightness(gamma(data.iter().cloned()), 10)).
+                await.unwrap();
+            Timer::after_millis(20).await;
+        }
+    }
+}
+
+// Example task to demonstrate that while the LED operation is going on,
+// something else can be done too with the power of async!
+#[embassy_executor::task]
+async fn background_print() {
+    loop {
+        defmt::info!("Hello from the background!");
+        Timer::after_secs(2).await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ where
         let config = TxChannelConfig::default()
             .with_clk_divider(1)
             .with_idle_output_level(Level::Low)
+            .with_memsize(2)
             .with_carrier_modulation(false)
             .with_idle_output(true);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,13 +91,22 @@ impl Timing for Ws2812Timing {
     const TIME_1_LOW: u16 = 600;
 }
 
-/// Timing for the WS2811 driver ICs.
+/// Timing for the WS2811 driver ICs, low-speed mode.
+pub enum Ws2811LowSpeedTiming {}
+impl Timing for Ws2811LowSpeedTiming {
+    const TIME_0_HIGH: u16 = 500;
+    const TIME_0_LOW: u16 = 2000;
+    const TIME_1_HIGH: u16 = 1200;
+    const TIME_1_LOW: u16 = 1300;
+}
+
+/// Timing for the WS2811 driver ICs, high-speed mode.
 pub enum Ws2811Timing {}
 impl Timing for Ws2811Timing {
-    const TIME_0_HIGH: u16 = 500;
-    const TIME_0_LOW: u16 = 1200;
-    const TIME_1_HIGH: u16 = 2000;
-    const TIME_1_LOW: u16 = 1300;
+    const TIME_0_HIGH: u16 = Ws2811LowSpeedTiming::TIME_0_HIGH / 2;
+    const TIME_0_LOW: u16 = Ws2811LowSpeedTiming::TIME_0_LOW / 2;
+    const TIME_1_HIGH: u16 = Ws2811LowSpeedTiming::TIME_1_HIGH / 2;
+    const TIME_1_LOW: u16 = Ws2811LowSpeedTiming::TIME_1_LOW / 2;
 }
 
 /// All types of errors that can happen during the conversion and transmission
@@ -385,7 +394,11 @@ where
         self.create_rmt_data(iterator)?;
 
         // Perform the actual RMT operation. We use the u32 values here right away.
-        self.channel.as_mut().unwrap().transmit(&self.rmt_buffer).await?;
+        self.channel
+            .as_mut()
+            .unwrap()
+            .transmit(&self.rmt_buffer)
+            .await?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-rmt-driver), which is based on the unofficial `esp-idf` SDK, this crate is based on the official no-std [esp-hal](https://github.com/esp-rs/esp-hal).
 //!
-//! This driver uses the blocking RMT API, which is not
+//! This driver uses the blocking RMT API, which is not suitable for use in async code. The [`SmartLedsWrite`] trait is implemented for [`SmartLedsAdapter`] only if a [`Blocking`] RMT channel is passed.
 //!
 //! ## Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,98 +1,226 @@
-//! This adapter allows for the use of an RMT output channel to easily interact
-//! with RGB LEDs and use the convenience functions of the
-//! [`smart-leds`](https://crates.io/crates/smart-leds) crate.
+//! Allows for the use of an RMT output channel on the ESP32 family to easily drive smart RGB LEDs. This is a driver for the [smart-leds](https://crates.io/crates/smart-leds) framework and allows using the utility functions from this crate as well as higher-level libraries based on smart-leds.
 //!
-//! This is a simple implementation where every LED is adressed in an
-//! individual RMT operation. This is working perfectly fine in blocking mode,
-//! but in case this is used in combination with interrupts that might disturb
-//! the sequential sending, an alternative implementation (addressing the LEDs
-//! in a sequence in a single RMT send operation) might be required!
+//! Different from [ws2812-esp32-rmt-driver](https://crates.io/crates/ws2812-esp32-rmt-driver), which is based on the unofficial `esp-idf` SDK, this crate is based on the official no-std [esp-hal](https://github.com/esp-rs/esp-hal).
+//!
+//! This driver uses the blocking RMT API, which is not
 //!
 //! ## Example
 //!
 //! ```rust,ignore
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), None).unwrap();
+//! let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(80)).unwrap();
 //!
-//! let rmt_buffer = smartLedBuffer!(1);
-//! let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer);
+//! let mut led = SmartLedsAdapter::<{ buffer_size(1) }, _, color_order::Rgb, Ws2812Timing>::new(
+//!     rmt.channel0, peripherals.GPIO2
+//! );
+//!
+//! led.write(brightness([RED], 10)).unwrap();
 //! ```
 //!
-//! ## Feature Flags
-#![doc = document_features::document_features!()]
+//! ## Usage overview
+//!
+//! The [`SmartLedsAdapter`] struct implements [`SmartLedsWrite`]
+//! and can be used to send color data to connected LEDs
+//! To initialize a [`SmartLedsAdapter`], use [`SmartLedsAdapter::new`],
+//! which takes an RMT channel and a [`PeripheralOutput`].
+//! If you want to reuse the channel afterwards, you can use [`esp_hal::rmt::ChannelCreator::reborrow`] to create a shorter-lived derived channel.
+//! [`SmartLedsAdapter`] is configured at compile-time to support a variety of LED configurations. See the documentation for [`SmartLedsAdapter`] for more info.
+//!
+//! ## Features
+//!
+//! None of the features provided by this crate are for external use, they are only used for testing and examples.
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![deny(missing_docs)]
 #![no_std]
 
-use core::{fmt::Debug, slice::IterMut};
+use core::{fmt::Debug, marker::PhantomData, slice::IterMut};
 
+pub use color_order::ColorOrder;
 use esp_hal::{
+    Blocking, DriverMode,
     clock::Clocks,
-    gpio::{interconnect::PeripheralOutput, Level},
-    peripheral::Peripheral,
-    rmt::{Error as RmtError, PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
+    gpio::{Level, interconnect::PeripheralOutput},
+    rmt::{Channel, Error as RmtError, PulseCode, Tx, TxChannelConfig, TxChannelCreator},
 };
-use smart_leds_trait::{SmartLedsWrite, RGB8};
+use smart_leds_trait::{RGB8, SmartLedsWrite};
 
-const SK68XX_CODE_PERIOD: u32 = 1200;
-const SK68XX_T0H_NS: u32 = 320;
-const SK68XX_T0L_NS: u32 = SK68XX_CODE_PERIOD - SK68XX_T0H_NS;
-const SK68XX_T1H_NS: u32 = 640;
-const SK68XX_T1L_NS: u32 = SK68XX_CODE_PERIOD - SK68XX_T1H_NS;
+/// Common trait for all different smart LED dependent timings.
+///
+/// All common smart LEDs are controlled by sending PWM-like pulses, in two different configurations for high and low.
+/// The required timings (and tolerances) can be found in the relevant datasheets.
+///
+/// Provided timings: [`Sk68xxTiming`], [`Ws2812bTiming`], [`Ws2811Timing`], [`Ws2812Timing`]
+// Implementations of this should be vacant enums so they can’t be constructed.
+pub trait Timing {
+    /// Low time for zero pulse, in nanoseconds.
+    const TIME_0_LOW: u16;
+    /// High time for zero pulse, in nanoseconds.
+    const TIME_0_HIGH: u16;
+    /// Low time for one pulse, in nanoseconds.
+    const TIME_1_LOW: u16;
+    /// High time for one pulse, in nanoseconds.
+    const TIME_1_HIGH: u16;
+}
+
+const SK68XX_CODE_PERIOD: u16 = 1200;
+/// Timing for the SK68 collection of LEDs.
+/// Note: it is not verified that this is correct, the datasheet for SK6812 says otherwise.
+/// These values have been carried over from an earlier version.
+pub enum Sk68xxTiming {}
+impl Timing for Sk68xxTiming {
+    const TIME_0_HIGH: u16 = 320;
+    const TIME_0_LOW: u16 = SK68XX_CODE_PERIOD - Self::TIME_0_HIGH;
+    const TIME_1_HIGH: u16 = 640;
+    const TIME_1_LOW: u16 = SK68XX_CODE_PERIOD - Self::TIME_1_HIGH;
+}
+
+/// Timing for the WS2812B LEDs.
+pub enum Ws2812bTiming {}
+impl Timing for Ws2812bTiming {
+    const TIME_0_HIGH: u16 = 400;
+    const TIME_0_LOW: u16 = 800;
+    const TIME_1_HIGH: u16 = 850;
+    const TIME_1_LOW: u16 = 450;
+}
+
+/// Timing for the WS2812 LEDs.
+pub enum Ws2812Timing {}
+impl Timing for Ws2812Timing {
+    const TIME_0_HIGH: u16 = 350;
+    const TIME_0_LOW: u16 = 700;
+    const TIME_1_HIGH: u16 = 800;
+    const TIME_1_LOW: u16 = 600;
+}
+
+/// Timing for the WS2811 driver ICs.
+pub enum Ws2811Timing {}
+impl Timing for Ws2811Timing {
+    const TIME_0_HIGH: u16 = 500;
+    const TIME_0_LOW: u16 = 1200;
+    const TIME_1_HIGH: u16 = 2000;
+    const TIME_1_LOW: u16 = 1300;
+}
 
 /// All types of errors that can happen during the conversion and transmission
-/// of LED commands
-#[derive(Debug)]
+/// of LED commands.
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum LedAdapterError {
-    /// Raised in the event that the provided data container is not large enough
+#[non_exhaustive]
+pub enum AdapterError {
+    /// Raised in the event that the RMT buffer is not large enough.
+    /// 
+    /// This almost always points to an issue with the `BUFFER_SIZE` parameter of [`SmartLedsAdapter`]. You should create this parameter using [`buffer_size`], passing in the desired number of LEDs that will be controlled.
     BufferSizeExceeded,
-    /// Raised if something goes wrong in the transmission,
+    /// Raised if something goes wrong in the transmission. This contains the inner HAL error ([`RmtError`]).
     TransmissionError(RmtError),
 }
 
-/// Macro to allocate a buffer sized for a specific number of LEDs to be
-/// addressed.
+/// Calculate the required buffer size for a certain number of LEDs. This should be used to create the `BUFFER_SIZE` parameter of [`SmartLedsAdapter`].
 ///
 /// Attempting to use more LEDs that the buffer is configured for will result in
-/// an `LedAdapterError:BufferSizeExceeded` error.
-#[macro_export]
-macro_rules! smartLedBuffer {
-    ( $buffer_size: literal ) => {
-        // The size we're assigning here is calculated as following
-        //  (
-        //   Nr. of LEDs
-        //   * channels (r,g,b -> 3)
-        //   * pulses per channel 8)
-        //  ) + 1 additional pulse for the end delimiter
-        [0u32; $buffer_size * 24 + 1]
-    };
+/// an [`AdapterError::BufferSizeExceeded`] error.
+pub const fn buffer_size(led_count: usize) -> usize {
+    // The size we're assigning here is calculated as following
+    //  (
+    //   Nr. of LEDs
+    //   * channels (r,g,b -> 3)
+    //   * pulses per channel 8)
+    //  ) + 1 additional pulse for the end delimiter
+    led_count * 24 + 1
 }
 
-/// Adapter taking an RMT channel and a specific pin and providing RGB LED
-/// interaction functionality using the `smart-leds` crate
-pub struct SmartLedsAdapter<TX, const BUFFER_SIZE: usize>
-where
-    TX: TxChannel,
-{
-    channel: Option<TX>,
-    rmt_buffer: [u32; BUFFER_SIZE],
-    pulses: (u32, u32),
+/// Common [`ColorOrder`] implementations.
+pub mod color_order {
+    use smart_leds_trait::RGB8;
+
+    /// Specific channel to request from [`ColorOrder`].
+    #[derive(Copy, Clone, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[repr(u8)]
+    pub enum Channel {
+        /// First channel.
+        First = 0,
+        /// Second channel.
+        Second = 1,
+        /// Third channel.
+        Third = 2,
+    }
+
+    /// Order of colors in the physical LEDs.
+    /// Some common color orders are:
+    /// - [`Rgb`] for WS2811
+    /// - [`Grb`] for SK86XX and WS2812(B)
+    // Implementations of this should be vacant enums so they can’t be constructed.
+    pub trait ColorOrder {
+        /// Retrieve the output value for the provided channel.
+        /// For instance, if color order is RGB, then the red value will be returned for channel 0,
+        /// the green value for channel 1 and the blue value for channel 2.
+        fn get_channel_data(color: RGB8, channel: Channel) -> u8;
+    }
+
+    /// [`ColorOrder`] RGB.
+    pub enum Rgb {}
+    impl ColorOrder for Rgb {
+        fn get_channel_data(color: RGB8, channel: Channel) -> u8 {
+            match channel {
+                Channel::First => color.r,
+                Channel::Second => color.g,
+                Channel::Third => color.b,
+            }
+        }
+    }
+
+    /// [`ColorOrder`] GRB.
+    pub enum Grb {}
+    impl ColorOrder for Grb {
+        fn get_channel_data(color: RGB8, channel: Channel) -> u8 {
+            match channel {
+                Channel::First => color.g,
+                Channel::Second => color.r,
+                Channel::Third => color.b,
+            }
+        }
+    }
 }
 
-impl<'d, TX, const BUFFER_SIZE: usize> SmartLedsAdapter<TX, BUFFER_SIZE>
+/// [`SmartLedsWrite`] driver implementation using the ESP32’s “remote control” (RMT) peripheral for hardware-offloaded, fast control of smart LEDs.
+///
+/// For usage examples and a general overview see [the crate documentation](`crate`).
+///
+/// This type supports many configurations of color order, LED timings, and LED count. For this reason, there are three main type parameters you have to choose:
+/// - The buffer size. This determines how many RMT pulses can be sent by this driver, and allows it to function entirely without heap allocation. It is strongly recommended to use the [`buffer_size`] function with the desired number of LEDs to choose a correct buffer size, otherwise [`SmartLedsWrite::write`] will return [`AdapterError::BufferSizeExceeded`].
+/// - The [`ColorOrder`]. This determines what order the LED expects the color values in. Almost all LEDs use [`color_order::Rgb`] or [`color_order::Grb`].
+/// - The [`Timing`]. This determines the smart LED type in use; what kind of signal it expects. Several implementations for common LED types like WS2812 are provided. Note that many WS2812-like LEDs are at least almost compatible in their timing, even though the datasheets specify different amounts, the other LEDs’ values are within the tolerance range, and even exceeding these, many LEDs continue to work beyond their specified timing range. It is however recommended to use the corresponding LED type, or implement your own when needed.
+///
+/// When the driver move is [`Blocking`], this type implements the blocking [`SmartLedsWrite`] interface. An async interface for [`esp_hal::Async`] may be added in the future. (You usually don’t need to choose this manually, Rust can deduce it from the passed-in RMT channel.)
+pub struct SmartLedsAdapter<'d, const BUFFER_SIZE: usize, Mode, Order, Timing>
 where
-    TX: TxChannel,
+    Mode: DriverMode,
+    Order: ColorOrder,
+    Timing: crate::Timing,
 {
-    /// Create a new adapter object that drives the pin using the RMT channel.
-    pub fn new<C, P>(
-        channel: C,
-        pin: impl Peripheral<P = P> + 'd,
-        rmt_buffer: [u32; BUFFER_SIZE],
-    ) -> SmartLedsAdapter<TX, BUFFER_SIZE>
+    channel: Option<Channel<'d, Mode, Tx>>,
+    rmt_buffer: [PulseCode; BUFFER_SIZE],
+    pulses: (PulseCode, PulseCode),
+    _order: PhantomData<Order>,
+    _timing: PhantomData<Timing>,
+}
+
+impl<'d, const BUFFER_SIZE: usize, Mode, Order, Timing>
+    SmartLedsAdapter<'d, BUFFER_SIZE, Mode, Order, Timing>
+where
+    Mode: DriverMode,
+    Order: ColorOrder,
+    Timing: crate::Timing,
+{
+    /// Creates a new [`SmartLedsAdapter`] that drives the provided output using the given RMT channel.
+    ///
+    /// Note that calling this function usually requires you to specify the desired buffer size, [`ColorOrder`] and [`Timing`]. See the struct documentation for details.
+    ///
+    /// If you want to reuse the channel afterwards, you can use [`esp_hal::rmt::ChannelCreator::reborrow`] to create a shorter-lived derived channel.
+    pub fn new<C, P>(channel: C, pin: P) -> SmartLedsAdapter<'d, BUFFER_SIZE, Mode, Order, Timing>
     where
-        C: TxChannelCreator<'d, TX, P>,
-        P: PeripheralOutput + Peripheral<P = P>,
+        C: TxChannelCreator<'d, Mode>,
+        P: PeripheralOutput<'d>,
     {
         let config = TxChannelConfig::default()
             .with_clk_divider(1)
@@ -100,51 +228,68 @@ where
             .with_carrier_modulation(false)
             .with_idle_output(true);
 
-        let channel = channel.configure(pin, config).unwrap();
+        let channel = channel.configure_tx(pin, config).unwrap();
 
         // Assume the RMT peripheral is set up to use the APB clock
         let clocks = Clocks::get();
-        let src_clock = clocks.apb_clock.as_hz() / 1_000_000; // convert to the MHz value to simplify nanosecond calculations
+        // convert to the MHz value to simplify nanosecond calculations
+        let src_clock = clocks.apb_clock.as_hz() / 1_000_000;
 
         Self {
             channel: Some(channel),
-            rmt_buffer,
+            rmt_buffer: [PulseCode::end_marker(); _],
             pulses: (
                 PulseCode::new(
                     Level::High,
-                    ((SK68XX_T0H_NS * src_clock) / 1000) as u16,
+                    ((Timing::TIME_0_HIGH as u32 * src_clock) / 1000) as u16,
                     Level::Low,
-                    ((SK68XX_T0L_NS * src_clock) / 1000) as u16,
+                    ((Timing::TIME_0_LOW as u32 * src_clock) / 1000) as u16,
                 ),
                 PulseCode::new(
                     Level::High,
-                    ((SK68XX_T1H_NS * src_clock) / 1000) as u16,
+                    ((Timing::TIME_1_HIGH as u32 * src_clock) / 1000) as u16,
                     Level::Low,
-                    ((SK68XX_T1L_NS * src_clock) / 1000) as u16,
+                    ((Timing::TIME_1_LOW as u32 * src_clock) / 1000) as u16,
                 ),
             ),
+            _order: PhantomData,
+            _timing: PhantomData,
         }
     }
 
     fn convert_rgb_to_pulse(
         value: RGB8,
-        mut_iter: &mut IterMut<u32>,
-        pulses: (u32, u32),
-    ) -> Result<(), LedAdapterError> {
-        Self::convert_rgb_channel_to_pulses(value.g, mut_iter, pulses)?;
-        Self::convert_rgb_channel_to_pulses(value.r, mut_iter, pulses)?;
-        Self::convert_rgb_channel_to_pulses(value.b, mut_iter, pulses)?;
+        mut_iter: &mut IterMut<PulseCode>,
+        pulses: (PulseCode, PulseCode),
+    ) -> Result<(), AdapterError> {
+        use crate::color_order::Channel;
+
+        Self::convert_rgb_channel_to_pulses(
+            Order::get_channel_data(value, Channel::First),
+            mut_iter,
+            pulses,
+        )?;
+        Self::convert_rgb_channel_to_pulses(
+            Order::get_channel_data(value, Channel::Second),
+            mut_iter,
+            pulses,
+        )?;
+        Self::convert_rgb_channel_to_pulses(
+            Order::get_channel_data(value, Channel::Third),
+            mut_iter,
+            pulses,
+        )?;
 
         Ok(())
     }
 
     fn convert_rgb_channel_to_pulses(
         channel_value: u8,
-        mut_iter: &mut IterMut<u32>,
-        pulses: (u32, u32),
-    ) -> Result<(), LedAdapterError> {
+        mut_iter: &mut IterMut<PulseCode>,
+        pulses: (PulseCode, PulseCode),
+    ) -> Result<(), AdapterError> {
         for position in [128, 64, 32, 16, 8, 4, 2, 1] {
-            *mut_iter.next().ok_or(LedAdapterError::BufferSizeExceeded)? =
+            *mut_iter.next().ok_or(AdapterError::BufferSizeExceeded)? =
                 match channel_value & position {
                     0 => pulses.0,
                     _ => pulses.1,
@@ -155,11 +300,13 @@ where
     }
 }
 
-impl<TX, const BUFFER_SIZE: usize> SmartLedsWrite for SmartLedsAdapter<TX, BUFFER_SIZE>
+impl<'d, const BUFFER_SIZE: usize, Order, Timing> SmartLedsWrite
+    for SmartLedsAdapter<'d, BUFFER_SIZE, Blocking, Order, Timing>
 where
-    TX: TxChannel,
+    Order: ColorOrder,
+    Timing: crate::Timing,
 {
-    type Error = LedAdapterError;
+    type Error = AdapterError;
     type Color = RGB8;
 
     /// Convert all RGB8 items of the iterator to the RMT format and
@@ -181,7 +328,7 @@ where
         }
 
         // Finally, add an end element.
-        *seq_iter.next().ok_or(LedAdapterError::BufferSizeExceeded)? = PulseCode::empty();
+        *seq_iter.next().ok_or(AdapterError::BufferSizeExceeded)? = PulseCode::end_marker();
 
         // Perform the actual RMT operation. We use the u32 values here right away.
         let channel = self.channel.take().unwrap();
@@ -192,7 +339,7 @@ where
             }
             Err((e, chan)) => {
                 self.channel = Some(chan);
-                Err(LedAdapterError::TransmissionError(e))
+                Err(AdapterError::TransmissionError(e))
             }
         }
     }


### PR DESCRIPTION
- Port to esp-hal 1.0 (version is pinned, as RMT is unstable and might change in every new release)
- Allow flexibly specifying LED timing modes and color order
- Implement common timings and color orders
- Improve dependency specification
- Change buffer size macro to remove the requirement to pre-allocate a stack buffer (when this can be done in the adapter directly)
- Fix both examples
- Add more documentation
- Remove documented-features as all the features are for development and examples only
- Improve docs-rs situation
- Make error type non-exhaustive so adding more errors won’t be a semver-breaking change
- Use edition 2024
- Align a lot of code more closely with common Rust practices
- Add async interface: when Rmt/Channel are async, we implement `SmartLedWriteAsync`.
- Example for async interface

I hope these changes are acceptable. They make the library more flexible and less error-prone to use, while requiring only minor changes for most users (different construction of the driver). The fundamental driver implementation hasn’t changed all that much.

For now I will publish this crate on crates.io as well, since there hasn’t been activity here since the esp-hal 1.0 release.